### PR TITLE
Add .gitignore and remove private keys from tracking

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,11 @@
+# WireGuard keys (NEVER commit these)
+privatekey
+publickey
+server_private.key
+server_public.key
+*.key
+*.conf
+
 # Logs
 logs
 *.log


### PR DESCRIPTION
Added .gitignore to prevent sensitive key files and build folders from being committed

Removed any previously tracked private keys

Helps keep the repo secure and clean